### PR TITLE
Remove train time since we have removed declarations before

### DIFF
--- a/mnist_vae_cnn/mnist_vae_cnn.cpp
+++ b/mnist_vae_cnn/mnist_vae_cnn.cpp
@@ -210,10 +210,6 @@ int main()
                  // Stop the training using Early Stop at min loss.
                  ens::EarlyStopAtMinLoss());
 
-  std::cout << "Time taken to train -> "
-            << float(clock() - begin_time) / CLOCKS_PER_SEC << " seconds"
-            << std::endl;
-
   // Save the model if specified.
   if (saveModel)
   {


### PR DESCRIPTION
It seems that I have deleted the clock declaration when
applying callbacks on all examples, but I have forget to
delete the train time calculated at the end of training.
This example is compiling now.

Signed-off-by: Omar Shrit <shrit@lri.fr>