### PR TITLE
Simplify Optimizers used in examples.

### DIFF
--- a/lstm_electricity_consumption/lstm_electricity_consumption.cpp
+++ b/lstm_electricity_consumption/lstm_electricity_consumption.cpp
@@ -240,14 +240,16 @@ int main()
       model.Add<Linear<> >(H1, outputSize);
     }
 
-    // Set parameters for the Stochastic Gradient Descent (SGD) optimizer.
-    SGD<AdamUpdate> optimizer(
-        STEP_SIZE, // Step size of the optimizer.
-        BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
-        trainData.n_cols * EPOCHS, // Max number of iterations.
-        1e-8, // Tolerance.
-        true, // Shuffle.
-        AdamUpdate(1e-8, 0.9, 0.999)); // Adam update policy.
+    // Set parameters for the Adam optimizer.
+    ens::Adam optimizer(
+    STEP_SIZE, // Step size of the optimizer.
+    BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+    0.9, // Exponential decay rate for the first moment estimates.
+    0.999, // Exponential decay rate for the weighted infinity norm estimates.
+    1e-8, // Value used to initialise the mean squared gradient parameter.
+    trainData.n_cols * EPOCHS, // Max number of iterations.
+    1e-8, // Tolerance.
+    true);
 
     // Instead of terminating based on the tolerance of the objective function,
     // we'll depend on the maximum number of iterations, and terminate early using

--- a/lstm_electricity_consumption/lstm_electricity_consumption.cpp
+++ b/lstm_electricity_consumption/lstm_electricity_consumption.cpp
@@ -242,14 +242,14 @@ int main()
 
     // Set parameters for the Adam optimizer.
     ens::Adam optimizer(
-    STEP_SIZE, // Step size of the optimizer.
-    BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
-    0.9, // Exponential decay rate for the first moment estimates.
-    0.999, // Exponential decay rate for the weighted infinity norm estimates.
-    1e-8, // Value used to initialise the mean squared gradient parameter.
-    trainData.n_cols * EPOCHS, // Max number of iterations.
-    1e-8, // Tolerance.
-    true);
+        STEP_SIZE, // Step size of the optimizer.
+        BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+        0.9, // Exponential decay rate for the first moment estimates.
+        0.999, // Exponential decay rate for the weighted infinity norm estimates.
+        1e-8, // Value used to initialise the mean squared gradient parameter.
+        trainData.n_cols * EPOCHS, // Max number of iterations.
+        1e-8, // Tolerance.
+        true);
 
     // Instead of terminating based on the tolerance of the objective function,
     // we'll depend on the maximum number of iterations, and terminate early using

--- a/lstm_stock_prediction/lstm_stock_prediction.cpp
+++ b/lstm_stock_prediction/lstm_stock_prediction.cpp
@@ -246,15 +246,16 @@ int main()
       model.Add<Linear<> >(H1, outputSize);
     }
 
-    // Set parameters for the Stochastic Gradient Descent (SGD) optimizer.
-    SGD<AdamUpdate> optimizer(
+    // Set parameters for the Adam optimizer.
+    ens::Adam optimizer(
         STEP_SIZE, // Step size of the optimizer.
-        BATCH_SIZE, // Batch size. Number of data points that are used in each
-                    // iteration.
+        BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+        0.9, // Exponential decay rate for the first moment estimates.
+        0.999, // Exponential decay rate for the weighted infinity norm estimates.
+        1e-8, // Value used to initialise the mean squared gradient parameter.
         trainData.n_cols * EPOCHS, // Max number of iterations.
-        1e-8,// Tolerance.
-        true, // Shuffle.
-        AdamUpdate(1e-8, 0.9, 0.999)); // Adam update policy.
+        1e-8, // Tolerance.
+        true);
 
     // Instead of terminating based on the tolerance of the objective function,
     // we'll depend on the maximum number of iterations, and terminate early using

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -124,23 +124,16 @@ int main()
 
   std::cout << "Training ..." << endl;
 
-  // Setting parameters Stochastic Gradient Descent (SGD) optimizer.
-  SGD<AdamUpdate> optimizer(
-      // Step size of the optimizer.
-      STEP_SIZE,
-      // Batch size. Number of data points that are used in each iteration.
-      BATCH_SIZE,
-      // Max number of iterations
-      MAX_ITERATIONS,
-      // Tolerance, used as a stopping condition. This small number
-      // means we never stop by this condition and continue to optimize
-      // up to reaching maximum of iterations.
-      1e-8,
-      // Shuffle. If optimizer should take random data points from the dataset
-      // at each iteration.
-      true,
-      // Adam update policy.
-      AdamUpdate(1e-8, 0.9, 0.999));
+  // Set parameters for the Adam optimizer.
+  ens::Adam optimizer(
+      STEP_SIZE, // Step size of the optimizer.
+      BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+      0.9, // Exponential decay rate for the first moment estimates.
+      0.999, // Exponential decay rate for the weighted infinity norm estimates.
+      1e-8, // Value used to initialise the mean squared gradient parameter.
+      MAX_ITERATIONS, // Max number of iterations.
+      1e-8, // Tolerance.
+      true);
 
   // Train neural network. If this is the first iteration, weights are
   // random, using current values as starting point otherwise.

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -158,23 +158,16 @@ int main()
 
   cout << "Start training ..." << endl;
 
-  // Set parameters of Stochastic Gradient Descent (SGD) optimizer.
-  SGD<AdamUpdate> optimizer(
-      // Step size of the optimizer.
-      STEP_SIZE,
-      // Batch size. Number of data points that are used in each iteration.
-      BATCH_SIZE,
-      // Max number of iterations.
-      MAX_ITERATIONS,
-      // Tolerance, used as a stopping condition. Such a small value
-      // means we almost never stop by this condition, and continue gradient
-      // descent until the maximum number of iterations is reached.
-      -1,
-      // Shuffle. If optimizer should take random data points from the dataset
-      // at each iteration.
-      true,
-      // Adam update policy.
-      AdamUpdate(1e-8, 0.9, 0.999));
+  // Set parameters for the Adam optimizer.
+  ens::Adam optimizer(
+      STEP_SIZE, // Step size of the optimizer.
+      BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+      0.9, // Exponential decay rate for the first moment estimates.
+      0.999, // Exponential decay rate for the weighted infinity norm estimates.
+      1e-8, // Value used to initialise the mean squared gradient parameter.
+      MAX_ITERATIONS, // Max number of iterations.
+      1e-8, // Tolerance.
+      true);
 
   // Train the CNN model. If this is the first iteration, weights are
   // randomly initialized between -1 and 1. Otherwise, the values of weights

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -110,23 +110,16 @@ int main()
 
   std::cout << "Start training ..." << std::endl;
 
-  // Setting parameters Stochastic Gradient Descent (SGD) optimizer.
-  SGD<AdamUpdate> optimizer(
-      // Step size of the optimizer.
-      STEP_SIZE,
-      // Batch size. Number of data points that are used in each iteration.
-      BATCH_SIZE,
-      // Max number of iterations
-      MAX_ITERATIONS,
-      // Tolerance, used as a stopping condition is set to -1.
-      // This value means we never stop by this condition and continue to
-      // optimize until we stopped by EarlyStopAtMinLoss.
-      -1,
-      // Shuffle. If optimizer should take random data points from the dataset
-      // at each iteration.
-      true,
-      // Adam update policy.
-      AdamUpdate(1e-8, 0.9, 0.999));
+  // Set parameters for the Adam optimizer.
+  ens::Adam optimizer(
+      STEP_SIZE, // Step size of the optimizer.
+      BATCH_SIZE, // Batch size. Number of data points that are used in each iteration.
+      0.9, // Exponential decay rate for the first moment estimates.
+      0.999, // Exponential decay rate for the weighted infinity norm estimates.
+      1e-8, // Value used to initialise the mean squared gradient parameter.
+      MAX_ITERATIONS, // Max number of iterations.
+      1e-8, // Tolerance.
+      true);
 
   // Train neural network. If this is the first iteration, weights are
   // random, using current values as starting point otherwise.

--- a/mnist_vae_cnn/mnist_vae_cnn.cpp
+++ b/mnist_vae_cnn/mnist_vae_cnn.cpp
@@ -60,7 +60,7 @@ int main()
   // Entire dataset(without labels) is loaded from a CSV file.
   // Each column represents a data point.
   arma::mat fullData;
-  data::Load("mnist_full.csv", fullData, true, false);
+  data::Load("./../data/mnist_full.csv", fullData, true, false);
   fullData /= 255.0;
 
   if (isBinary)
@@ -179,23 +179,16 @@ int main()
 
   std::cout << "Training ..." << std::endl;
 
-  // Setting parameters for the Stochastic Gradient Descent (SGD) optimizer.
-  SGD<AdamUpdate> optimizer(
-    // Step size of the optimizer.
-    stepSize,
-    // Number of data points that are used in each iteration.
-    batchSize,
-    // Max number of iterations.
-    maxIteration,
-    // Tolerance, used as a stopping condition. This small number means we never
-    // stop by this condition and continue to optimize up to reaching maximum of
-    // iterations.
-    -1,
-    // Shuffle, If optimizer should take random data points from the dataset at
-    // each iteration.
-    true,
-    // Adam update policy.
-    AdamUpdate());
+  // Set parameters for the Adam optimizer.
+  ens::Adam optimizer(
+      stepSize, // Step size of the optimizer.
+      batchSize, // Batch size. Number of data points that are used in each iteration.
+      0.9, // Exponential decay rate for the first moment estimates.
+      0.999, // Exponential decay rate for the weighted infinity norm estimates.
+      1e-8, // Value used to initialise the mean squared gradient parameter.
+      maxIteration, // Max number of iterations.
+      1e-8, // Tolerance.
+      true);
 
   std::cout << "Initial loss -> " <<
       MeanTestLoss<MeanSModel>(vaeModel, train_test, 50) << std::endl;


### PR DESCRIPTION
This is in reference to a comment in #72 by @rcurtin to simplify optimizers. Here instead of using  `SGD<AdamUpdate>` with AdamUpate we can simply use `Adam`

Let me know what you think. Thanks a lot.