### PR TITLE
Use this repo's start year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2007-2020, mlpack
+Copyright (c) 2017-2020, mlpack
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Following #86 and https://github.com/mlpack/models/pull/6, change start date in copyright notice to 2017