### PR TITLE
Change mnist full to mnist train

### DIFF
--- a/mnist_vae_cnn/mnist_vae_cnn.cpp
+++ b/mnist_vae_cnn/mnist_vae_cnn.cpp
@@ -60,7 +60,7 @@ int main()
   // Entire dataset(without labels) is loaded from a CSV file.
   // Each column represents a data point.
   arma::mat fullData;
-  data::Load("./../data/mnist_full.csv", fullData, true, false);
+  data::Load("../data/mnist_train.csv", fullData, true, false);
   fullData /= 255.0;
 
   if (isBinary)


### PR DESCRIPTION
It seems that mnist full was just a sample of the original
mnist dataset with around 700 lines. The mnist train has at least
66K lines.  It should be enough for this example.

Signed-off-by: Omar Shrit <omar@shrit.me>