### PR TITLE
Early stop

### DIFF
--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -148,10 +148,10 @@ int main()
                   [&](const arma::mat& /* param */)
                   {
                     double validationLoss =
-                    model.Evaluate(validX, validY);
-                    std::cout << "Validation loss: "
-                              << validationLoss
-                              << std::endl;
+                        model.Evaluate(validX, validY);
+                        std::cout << "Validation loss: "
+                                  << validationLoss
+                                  << std::endl;
                     return validationLoss;
                   }));
   mat predOut;

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -147,11 +147,9 @@ int main()
               ens::EarlyStopAtMinLoss<arma::mat>(
                   [&](const arma::mat& /* param */)
                   {
-                    double validationLoss =
-                        model.Evaluate(validX, validY);
-                        std::cout << "Validation loss: "
-                                  << validationLoss
-                                  << std::endl;
+                    double validationLoss = model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: " << validationLoss
+                        << "." << std::endl;
                     return validationLoss;
                   }));
   mat predOut;

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -144,7 +144,7 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss<arma::mat>(
+              ens::EarlyStopAtMinLoss(
                   [&](const arma::mat& /* param */)
                   {
                     double validationLoss = model.Evaluate(validX, validY);

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -144,8 +144,16 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss());
-
+              ens::EarlyStopAtMinLoss<arma::mat>(
+                  [&](const arma::mat& /* param */)
+                  {
+                    double validationLoss =
+                    model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: "
+                              << validationLoss
+                              << std::endl;
+                    return validationLoss;
+                  }));
   mat predOut;
   // Getting predictions on training data points.
   model.Predict(trainX, predOut);

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -179,7 +179,7 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss<arma::mat>(
+              ens::EarlyStopAtMinLoss(
                   [&](const arma::mat& /* param */)
                     double validationLoss = model.Evaluate(validX, validY);
                     std::cout << "Validation loss: " << validationLoss

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -179,7 +179,16 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss());
+              ens::EarlyStopAtMinLoss<arma::mat>(
+                  [&](const arma::mat& /* param */)
+                  {
+                    double validationLoss =
+                    model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: "
+                              << validationLoss
+                              << std::endl;
+                    return validationLoss;
+                  }));
 
   // Matrix to store the predictions on train and validation datasets.
   mat predOut;

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -183,10 +183,10 @@ int main()
                   [&](const arma::mat& /* param */)
                   {
                     double validationLoss =
-                    model.Evaluate(validX, validY);
-                    std::cout << "Validation loss: "
-                              << validationLoss
-                              << std::endl;
+                      model.Evaluate(validX, validY);
+                      std::cout << "Validation loss: "
+                                << validationLoss
+                                << std::endl;
                     return validationLoss;
                   }));
 

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -181,12 +181,9 @@ int main()
               // Stop the training using Early Stop at min loss.
               ens::EarlyStopAtMinLoss<arma::mat>(
                   [&](const arma::mat& /* param */)
-                  {
-                    double validationLoss =
-                      model.Evaluate(validX, validY);
-                      std::cout << "Validation loss: "
-                                << validationLoss
-                                << std::endl;
+                    double validationLoss = model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: " << validationLoss
+                        << "." << std::endl;
                     return validationLoss;
                   }));
 

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -130,7 +130,16 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss());
+              ens::EarlyStopAtMinLoss<arma::mat>(
+                  [&](const arma::mat& /* param */)
+                  {
+                    double validationLoss =
+                    model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: "
+                              << validationLoss
+                              << std::endl;
+                    return validationLoss;
+                  }));
 
   mat predOut;
   // Getting predictions on training data points.

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -133,12 +133,9 @@ int main()
               ens::EarlyStopAtMinLoss<arma::mat>(
                   [&](const arma::mat& /* param */)
                   {
-                    double validationLoss =
-                      model.Evaluate(validX, validY);
-                      std::cout << "Validation loss: "
-                                << validationLoss
-                                << std::endl;
-                    return validationLoss;
+                    double validationLoss = model.Evaluate(validX, validY);
+                    std::cout << "Validation loss: " << validationLoss
+                        << "." << std::endl;
                   }));
 
   mat predOut;

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -130,7 +130,7 @@ int main()
               ens::PrintLoss(),
               ens::ProgressBar(),
               // Stop the training using Early Stop at min loss.
-              ens::EarlyStopAtMinLoss<arma::mat>(
+              ens::EarlyStopAtMinLoss(
                   [&](const arma::mat& /* param */)
                   {
                     double validationLoss = model.Evaluate(validX, validY);

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -134,10 +134,10 @@ int main()
                   [&](const arma::mat& /* param */)
                   {
                     double validationLoss =
-                    model.Evaluate(validX, validY);
-                    std::cout << "Validation loss: "
-                              << validationLoss
-                              << std::endl;
+                      model.Evaluate(validX, validY);
+                      std::cout << "Validation loss: "
+                                << validationLoss
+                                << std::endl;
                     return validationLoss;
                   }));
 


### PR DESCRIPTION
This pull request updates the early stop callback to stop the training when the loss stops decreasing on the validation loss rather than the training loss.