### PR TITLE
Use 0 to numClass Labels instead of 1 to 10 where NLL is used.

### DIFF
--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -79,13 +79,9 @@ int main()
   const mat trainX = train.submat(1, 0, train.n_rows - 1, train.n_cols - 1);
   const mat validX = valid.submat(1, 0, valid.n_rows - 1, valid.n_cols - 1);
 
-  // According to NegativeLogLikelihood output layer of NN, labels should
-  // specify class of a data point and be in the interval from 1 to
-  // number of classes (in this case from 1 to 10).
-
   // Create labels for training and validatiion datasets.
-  const mat trainY = train.row(0) + 1;
-  const mat validY = valid.row(0) + 1;
+  const mat trainY = train.row(0);
+  const mat validY = valid.row(0);
 
   // Specify the NN model. NegativeLogLikelihood is the output layer that
   // is used for classification problem. RandomInitialization means that
@@ -194,13 +190,13 @@ int main()
   // Calculate accuracy on training data points.
   arma::Row<size_t> predLabels = getLabels(predOut);
   double trainAccuracy =
-      arma::accu(predLabels == trainY) / ( double )trainY.n_elem * 100;
+      arma::accu(predLabels == trainY) / (double) trainY.n_elem * 100;
   // Get predictions on validating data points.
   model.Predict(validX, predOut);
   // Calculate accuracy on validating data points.
   predLabels = getLabels(predOut);
   double validAccuracy =
-      arma::accu(predLabels == validY) / ( double )validY.n_elem * 100;
+      arma::accu(predLabels == validY) / (double) validY.n_elem * 100;
 
   std::cout << "Accuracy: train = " << trainAccuracy << "%,"
             << "\t valid = " << validAccuracy << "%" << std::endl;

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -62,7 +62,7 @@ int main()
 
   // The original file can be downloaded from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/train.csv", tempDataset, true);
+  data::Load("../data/mnist_train.csv", tempDataset, true);
 
   // The original Kaggle dataset CSV file has headings for each column,
   // so it's necessary to get rid of the first row. In Armadillo representation,
@@ -122,7 +122,7 @@ int main()
                            28, // Input width.
                            28  // Input height.
   );
-
+  model.Add<BatchNorm<>>(6, 1e-8, false);
   // Add first ReLU.
   model.Add<LeakyReLU<>>();
 
@@ -145,7 +145,7 @@ int main()
                            12, // Input width.
                            12  // Input height.
   );
-
+  model.Add<BatchNorm<>>(16, 1e-8, false);
   // Add the second ReLU.
   model.Add<LeakyReLU<>>();
 

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -77,13 +77,9 @@ int main()
   const arma::mat validX =
       valid.submat(1, 0, valid.n_rows - 1, valid.n_cols - 1) / 255.0;
 
-  // According to NegativeLogLikelihood output layer of NN, labels should
-  // specify class of a data point and be in the interval from 1 to
-  // number of classes (in this case from 1 to 10).
-
   // Creating labels for training and validating dataset.
-  const arma::mat trainY = train.row(0) + 1;
-  const arma::mat validY = valid.row(0) + 1;
+  const arma::mat trainY = train.row(0);
+  const arma::mat validY = valid.row(0);
 
   // Specifying the NN model. NegativeLogLikelihood is the output layer that
   // is used for classification problem. GlorotInitialization means that


### PR DESCRIPTION
Hey everyone,
This PR makes the change from 0 to numClasses for training labels. The PR will be merged after mlpack/mlpack#2534. This PR also adds BatchNorm for ConvLayer to give better output and faster convergence.
Kindly let me know your thoughts.

Regards,
Kartik.