### PR TITLE
Fix paths in some examples.

### DIFF
--- a/lstm_electricity_consumption/lstm_electricity_consumption.cpp
+++ b/lstm_electricity_consumption/lstm_electricity_consumption.cpp
@@ -127,7 +127,7 @@ int main()
   // Change the names of these files as necessary. They should be correct
   // already, if your program's working directory contains the data and/or
   // model.
-  const string dataFile = "electricity-usage.csv";
+  const string dataFile = "../data/electricity-usage.csv";
   // example: const string dataFile =
   //                  "C:/mlpack-model-app/electricity-usage.csv";
   // example: const string dataFile =

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -76,7 +76,7 @@ int main()
   mat tempDataset;
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/train.csv", tempDataset, true);
+  data::Load("../data/mnist_train.csv", tempDataset, true);
 
   // Originally on Kaggle dataset CSV file has header, so it's necessary to
   // get rid of the this row, in Armadillo representation it's the first column.
@@ -183,7 +183,7 @@ int main()
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
 
-  mlpack::data::Load("../data/test.csv", tempDataset, true);
+  mlpack::data::Load("../data/mnist_test.csv", tempDataset, true);
 
   mat testX =
       tempDataset.submat(0, 1, tempDataset.n_rows - 1, tempDataset.n_cols - 1);

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -140,6 +140,7 @@ int main()
                     double validationLoss = model.Evaluate(validX, validY);
                     std::cout << "Validation loss: " << validationLoss
                         << "." << std::endl;
+                    return validationLoss;
                   }));
 
   mat predOut;
@@ -168,7 +169,7 @@ int main()
 
   // As before, it's necessary to get rid of header.
   arma::mat testX = testingDataset.submat(
-      0, 1, testingDataset.n_rows - 1, testingDataset.n_cols - 1);
+      0, 1, testingDataset.n_rows - 2, testingDataset.n_cols - 1);
 
   std::cout << "Predicting ..." << endl;
   mat testPredOut;


### PR DESCRIPTION
While playing with the examples, I noticed that the paths aren't always the same as what the data downloader script saves things as.  These simple changes fix that.