### PR TITLE
CI add cereal dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
   - wget https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz
   - tar -xvzpf v1.3.0.tar.gz
+  - cd cereal-1.3.0
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr .
+  - make
+  - make install
 
   # Build mlpack.
   - cd $TRAVIS_BUILD_DIR
@@ -40,7 +44,7 @@ before_install:
   - cd mlpack
   - mkdir build
   - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DUSE_OPENMP=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_MARKDOWN_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF -DBUILD_TESTS=OFF -DCEREAL_INCLUDE_DIR=$TRAVIS_BUILD_DIR/cereal-1.3.0/include/ ..
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DUSE_OPENMP=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_MARKDOWN_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF -DBUILD_TESTS=OFF ..
   - make -j2
   - sudo make install
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - cd cereal-1.3.0
   - cmake -DCMAKE_INSTALL_PREFIX=/usr .
   - make
-  - make install
+  - sudo make install
 
   # Build mlpack.
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: cpp
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq --no-install-recommends cmake binutils-dev libopenblas-dev liblapack-dev build-essential libboost-all-dev
+  - sudo apt-get install -qq --no-install-recommends cmake binutils-dev libopenblas-dev liblapack-dev build-essential libboost-all-dev g++-multilib
 
   - mkdir deps/
   - cd deps/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,18 @@ before_install:
   - sudo make install
   - cd ../
 
+  # Install cereal.
+  - cd $TRAVIS_BUILD_DIR
+  - wget https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz
+  - tar -xvzpf v1.3.0.tar.gz
+
   # Build mlpack.
   - cd $TRAVIS_BUILD_DIR
   - git clone https://github.com/mlpack/mlpack.git --depth 1
   - cd mlpack
   - mkdir build
   - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DUSE_OPENMP=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_MARKDOWN_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF -DBUILD_TESTS=OFF ..
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DUSE_OPENMP=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_MARKDOWN_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF -DBUILD_TESTS=OFF -DCEREAL_INCLUDE_DIR=$TRAVIS_BUILD_DIR/cereal-1.3.0/include/ ..
   - make -j2
   - sudo make install
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_install:
   - cmake -DCMAKE_INSTALL_PREFIX=/usr .
   - make
   - sudo make install
+  - cd $TRAVIS_BUILD_DIR
+  - sudo rm -rf cereal-1.3.0
 
   # Build mlpack.
   - cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
mlpack serialization builds on cereal, which is currently not part of the CI build pipeline.