### PR TITLE
Adapt to new NegativeLogLikelihood convention.

### DIFF
--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -41,7 +41,7 @@ arma::Row<size_t> getLabels(arma::mat predOut)
   arma::Row<size_t> predLabels(predOut.n_cols);
   for (arma::uword i = 0; i < predOut.n_cols; ++i)
   {
-    predLabels(i) = predOut.col(i).index_max() + 1;
+    predLabels(i) = predOut.col(i).index_max();
   }
   return predLabels;
 }

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -91,13 +91,12 @@ int main()
   const mat trainX = train.submat(1, 0, train.n_rows - 1, train.n_cols - 1);
   const mat validX = valid.submat(1, 0, valid.n_rows - 1, valid.n_cols - 1);
 
-  // According to NegativeLogLikelihood output layer of NN, labels should
-  // specify class of a data point and be in the interval from 1 to
-  // number of classes (in this case from 1 to 10).
+  // Labels should specify the class of a data point and be in the interval [0,
+  // numClasses).
 
   // Creating labels for training and validating dataset.
-  const mat trainY = train.row(0) + 1;
-  const mat validY = valid.row(0) + 1;
+  const mat trainY = train.row(0);
+  const mat validY = valid.row(0);
 
   // Specifying the NN model. NegativeLogLikelihood is the output layer that
   // is used for classification problem. RandomInitialization means that
@@ -162,13 +161,13 @@ int main()
   // Calculating accuracy on training data points.
   Row<size_t> predLabels = getLabels(predOut);
   double trainAccuracy =
-      arma::accu(predLabels == trainY) / ( double )trainY.n_elem * 100;
+      arma::accu(predLabels == trainY) / (double) trainY.n_elem * 100;
   // Getting predictions on validating data points.
   model.Predict(validX, predOut);
   // Calculating accuracy on validating data points.
   predLabels = getLabels(predOut);
   double validAccuracy =
-      arma::accu(predLabels == validY) / ( double )validY.n_elem * 100;
+      arma::accu(predLabels == validY) / (double) validY.n_elem * 100;
 
   std::cout << "Accuracy: train = " << trainAccuracy << "%,"
             << " valid = " << validAccuracy << "%" << endl;

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -38,7 +38,7 @@ arma::Row<size_t> getLabels(arma::mat predOut)
   arma::Row<size_t> predLabels(predOut.n_cols);
   for (arma::uword i = 0; i < predOut.n_cols; ++i)
   {
-    predLabels(i) = predOut.col(i).index_max() + 1;
+    predLabels(i) = predOut.col(i).index_max();
   }
   return predLabels;
 }

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -83,13 +83,12 @@ int main()
   const mat trainX = train.submat(1, 0, train.n_rows - 1, train.n_cols - 1);
   const mat validX = valid.submat(1, 0, valid.n_rows - 1, valid.n_cols - 1);
 
-  // According to NegativeLogLikelihood output layer of NN, labels should
-  // specify class of a data point and be in the interval from 1 to
-  // number of classes (in this case from 1 to 10).
+  // Labels should specify the class of a data point and be in the interval [0,
+  // numClasses).
 
   // Create labels for training and validatiion datasets.
-  const mat trainY = train.row(0) + 1;
-  const mat validY = valid.row(0) + 1;
+  const mat trainY = train.row(0);
+  const mat validY = valid.row(0);
 
   // Specify the NN model. NegativeLogLikelihood is the output layer that
   // is used for classification problem. RandomInitialization means that
@@ -199,13 +198,13 @@ int main()
   // Calculate accuracy on training data points.
   arma::Row<size_t> predLabels = getLabels(predOut);
   double trainAccuracy =
-      arma::accu(predLabels == trainY) / ( double )trainY.n_elem * 100;
+      arma::accu(predLabels == trainY) / (double) trainY.n_elem * 100;
   // Get predictions on validating data points.
   model.Predict(validX, predOut);
   // Calculate accuracy on validating data points.
   predLabels = getLabels(predOut);
   double validAccuracy =
-      arma::accu(predLabels == validY) / ( double )validY.n_elem * 100;
+      arma::accu(predLabels == validY) / (double) validY.n_elem * 100;
 
   std::cout << "Accuracy: train = " << trainAccuracy << "%,"
             << "\t valid = " << validAccuracy << "%" << std::endl;

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -81,13 +81,12 @@ int main()
   const arma::mat validX =
       valid.submat(1, 0, valid.n_rows - 1, valid.n_cols - 1) / 255.0;
 
-  // According to NegativeLogLikelihood output layer of NN, labels should
-  // specify class of a data point and be in the interval from 1 to
-  // number of classes (in this case from 1 to 10).
+  // Labels should specify the class of a data point and be in the interval [0,
+  // numClasses).
 
   // Creating labels for training and validating dataset.
-  const arma::mat trainY = train.row(0) + 1;
-  const arma::mat validY = valid.row(0) + 1;
+  const arma::mat trainY = train.row(0);
+  const arma::mat validY = valid.row(0);
 
   // Specifying the NN model. NegativeLogLikelihood is the output layer that
   // is used for classification problem. GlorotInitialization means that
@@ -157,13 +156,13 @@ int main()
   // Calculating accuracy on training data points.
   arma::Row<size_t> predLabels = getLabels(predOut);
   double trainAccuracy =
-      arma::accu(predLabels == trainY) / ( double )trainY.n_elem * 100;
+      arma::accu(predLabels == trainY) / (double) trainY.n_elem * 100;
   // Getting predictions on validating data points.
   model.Predict(validX, predOut);
   // Calculating accuracy on validating data points.
   predLabels = getLabels(predOut);
   double validAccuracy =
-      arma::accu(predLabels == validY) / ( double )validY.n_elem * 100;
+      arma::accu(predLabels == validY) / (double) validY.n_elem * 100;
 
   std::cout << "Accuracy: train = " << trainAccuracy << "%,"
             << "\t valid = " << validAccuracy << "%" << endl;

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -39,7 +39,7 @@ arma::Row<size_t> getLabels(arma::mat predOut)
   arma::Row<size_t> predLabels(predOut.n_cols);
   for (arma::uword i = 0; i < predOut.n_cols; ++i)
   {
-    predLabels(i) = predOut.col(i).index_max() + 1;
+    predLabels(i) = predOut.col(i).index_max();
   }
   return predLabels;
 }

--- a/mnist_vae_cnn/mnist_vae_cnn.cpp
+++ b/mnist_vae_cnn/mnist_vae_cnn.cpp
@@ -70,7 +70,9 @@ int main()
         arma::randu<arma::mat>(fullData.n_rows, fullData.n_cols) <= fullData);
   }
   else
+  {
     fullData = (fullData - 0.5) * 2;
+  }
 
   arma::mat train, validation;
   data::Split(fullData, validation, train, trainRatio);


### PR DESCRIPTION
This changes the examples that use the `NegativeLogLikelihood<>` class to use labels from `0` to `numClasses - 1`, instead of `1` to `numClasses`.

This is a planned change for mlpack 4.0.0, and should be merged in sync with https://github.com/mlpack/mlpack/pull/2534.

(The build will probably fail until mlpack 4.0.0 is merged.)