### PR TITLE
Don't remove header row from MNIST data

### DIFF
--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -73,15 +73,10 @@ int main()
 
   // Labeled dataset that contains data for training is loaded from CSV file,
   // rows represent features, columns represent data points.
-  mat tempDataset;
+  mat dataset;
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/mnist_train.csv", tempDataset, true);
-
-  // Originally on Kaggle dataset CSV file has header, so it's necessary to
-  // get rid of the this row, in Armadillo representation it's the first column.
-  mat dataset =
-      tempDataset.submat(0, 1, tempDataset.n_rows - 1, tempDataset.n_cols - 1);
+  data::Load("../data/mnist_train.csv", dataset, true);
 
   // Splitting the dataset on training and validation parts.
   mat train, valid;
@@ -182,14 +177,11 @@ int main()
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
 
-  mlpack::data::Load("../data/mnist_test.csv", tempDataset, true);
-
-  mat testX =
-      tempDataset.submat(1, 0, tempDataset.n_rows - 1, tempDataset.n_cols - 1);
+  mlpack::data::Load("../data/mnist_test.csv", dataset, true);
 
   mat testPredOut;
   // Getting predictions on test data points .
-  model.Predict(testX, testPredOut);
+  model.Predict(dataset, testPredOut);
   // Generating labels for the test dataset.
   Row<size_t> testPred = getLabels(testPredOut);
   std::cout << "Saving predicted labels to \"results.csv\"" << endl;

--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -178,6 +178,7 @@ int main()
   // https://www.kaggle.com/c/digit-recognizer/data
 
   mlpack::data::Load("../data/mnist_test.csv", dataset, true);
+  dataset.shed_row(dataset.n_rows - 1); // Remove labels.
 
   mat testPredOut;
   // Getting predictions on test data points .

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -62,17 +62,11 @@ int main()
 
   // Labeled dataset that contains data for training is loaded from CSV file.
   // Rows represent features, columns represent data points.
-  mat tempDataset;
+  mat dataset;
 
   // The original file can be downloaded from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/mnist_train.csv", tempDataset, true);
-
-  // The original Kaggle dataset CSV file has headings for each column,
-  // so it's necessary to get rid of the first row. In Armadillo representation,
-  // this corresponds to the first column of our data matrix.
-  mat dataset =
-      tempDataset.submat(0, 1, tempDataset.n_rows - 1, tempDataset.n_cols - 1);
+  data::Load("../data/mnist_train.csv", dataset, true);
 
   // Split the dataset into training and validation sets.
   mat train, valid;
@@ -216,16 +210,12 @@ int main()
   // Load test dataset
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/mnist_test.csv", tempDataset, true);
-
-  // As before, it's necessary to get rid of column headings.
-  mat testX =
-      tempDataset.submat(0, 1, tempDataset.n_rows - 1, tempDataset.n_cols - 1);
+  data::Load("../data/mnist_test.csv", dataset, true);
 
   // Matrix to store the predictions on test dataset.
   mat testPredOut;
   // Get predictions on test data points.
-  model.Predict(testX, testPredOut);
+  model.Predict(dataset, testPredOut);
   // Generate labels for the test dataset.
   Row<size_t> testPred = getLabels(testPredOut);
   std::cout << "Saving predicted labels to \"results.csv.\"..." << std::endl;

--- a/mnist_cnn/mnist_cnn.cpp
+++ b/mnist_cnn/mnist_cnn.cpp
@@ -211,6 +211,7 @@ int main()
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
   data::Load("../data/mnist_test.csv", dataset, true);
+  dataset.shed_row(dataset.n_rows - 1); // Remove labels before predicting.
 
   // Matrix to store the predictions on test dataset.
   mat testPredOut;

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -172,6 +172,7 @@ int main()
   // Loading test dataset (the one whose predicted labels
   // should be sent to kaggle website).
   mlpack::data::Load("../data/mnist_test.csv", dataset, true);
+  dataset.shed_row(dataset.n_rows - 1); // Strip labels before predicting.
 
   std::cout << "Predicting ..." << endl;
   mat testPredOut;

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -171,17 +171,12 @@ int main()
 
   // Loading test dataset (the one whose predicted labels
   // should be sent to kaggle website).
-  arma::mat testingDataset;
-  mlpack::data::Load("../data/mnist_test.csv", testingDataset, true);
-
-  // As before, it's necessary to get rid of header.
-  arma::mat testX = testingDataset.submat(
-      0, 1, testingDataset.n_rows - 2, testingDataset.n_cols - 1);
+  mlpack::data::Load("../data/mnist_test.csv", dataset, true);
 
   std::cout << "Predicting ..." << endl;
   mat testPredOut;
   // Getting predictions on test data points.
-  model.Predict(testX, testPredOut);
+  model.Predict(dataset, testPredOut);
   // Generating labels for the test dataset.
   Row<size_t> testPred = getLabels(testPredOut);
   std::cout << "Saving predicted labels to \"results.csv\" ..." << std::endl;

--- a/mnist_vae_cnn/mnist_vae_cnn.cpp
+++ b/mnist_vae_cnn/mnist_vae_cnn.cpp
@@ -61,7 +61,6 @@ int main()
   // Each column represents a data point.
   arma::mat fullData;
   data::Load("../data/mnist_train.csv", fullData, true, false);
-  fullData = fullData.submat(0, 1, fullData.n_rows - 1, fullData.n_cols - 1);
   fullData /= 255.0;
 
   if (isBinary)


### PR DESCRIPTION
The MNIST data that we download and preprocess doesn't have a header row, so there's no need to remove one.  This also cleans up a little bit of code here and there.