### PR TITLE
Use datasets.mlpack.org as the source for the datasets

### DIFF
--- a/avocado_price_prediction_with_linear_regression/avocado_price_prediction_with_lr_cpp.ipynb
+++ b/avocado_price_prediction_with_linear_regression/avocado_price_prediction_with_lr_cpp.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -q https://mlpack.org/datasets/avocado.csv.gz"
+    "!wget -q https://datasets.mlpack.org/avocado.csv.gz"
    ]
   },
   {

--- a/avocado_price_prediction_with_linear_regression/avocado_price_prediction_with_lr_py.ipynb
+++ b/avocado_price_prediction_with_linear_regression/avocado_price_prediction_with_lr_py.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -q https://mlpack.org/datasets/avocado.csv.gz"
+    "!wget -q https://datasets.mlpack.org/avocado.csv.gz"
    ]
   },
   {

--- a/salary_prediction_with_linear_regression/salary-prediction-linear-regression-cpp.ipynb
+++ b/salary_prediction_with_linear_regression/salary-prediction-linear-regression-cpp.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -q https://mlpack.org/datasets/Salary_Data.csv"
+    "!wget -q https://datasets.mlpack.org/Salary_Data.csv"
    ]
   },
   {

--- a/salary_prediction_with_linear_regression/salary-prediction-linear-regression-py.ipynb
+++ b/salary_prediction_with_linear_regression/salary-prediction-linear-regression-py.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "# Load the salary dataset.\n",
-    "data = pd.read_csv(\"https://mlpack.org/datasets/Salary_Data.csv\")"
+    "data = pd.read_csv(\"https://datasets.mlpack.org/Salary_Data.csv\")"
    ]
   },
   {

--- a/tools/download_data_set.py
+++ b/tools/download_data_set.py
@@ -112,22 +112,22 @@ def mnist_dataset():
 
 def electricity_consumption_dataset():
   print("Download the electricty consumption example datasets")
-  electricity = requests.get("https://www.mlpack.org/datasets/examples/electricity-usage.csv")
+  electricity = requests.get("https://datasets.mlpack.org/examples/electricity-usage.csv")
   progress_bar("electricity-usage.csv", electricity)
 
 def stock_exchange_dataset():
   print("Download the stock exchange example datasets")
-  stock = requests.get("https://www.mlpack.org/datasets/examples/Google2016-2019.csv")
+  stock = requests.get("https://datasets.mlpack.org/examples/Google2016-2019.csv")
   progress_bar("Google2016-2019.csv", stock)
 
 def body_fat_dataset():
   print("Download the body fat datasets")
-  bodyFat = requests.get("https://www.mlpack.org/datasets/examples/bodyfat.tsv")
+  bodyFat = requests.get("https://datasets.mlpack.org/examples/bodyfat.tsv")
   progress_bar("BodyFat.tsv", bodyFat)
 
 def iris_dataset():
   print("Downloading iris datasets...")
-  iris = requests.get("https://www.mlpack.org/datasets/iris.tar.gz")
+  iris = requests.get("https://datasets.mlpack.org/iris.tar.gz")
   progress_bar("iris.tar.gz", iris)
   tar = tarfile.open("iris.tar.gz", "r:gz")
   tar.extractall()
@@ -136,7 +136,7 @@ def iris_dataset():
 
 def salary_dataset():
   print("Downloading salary dataset...")
-  salary = requests.get("http://mlpack.org/datasets/Salary_Data.csv")
+  salary = requests.get("http://datasets.mlpack.org/Salary_Data.csv")
   progress_bar("Salary_Data.csv", salary)
   
 def all_datasets():


### PR DESCRIPTION
I unpacked `datasets.tar.gz` into `datasets.mlpack.org/`.  That should make it a bit easier to maintain the website, and simplify the website building scripts.  So, this PR makes all the download scripts use that subdomain as a source for the datasets. Let me know if I overlooked anything! :)