### PR TITLE
Add imbalanced-learn conda pkg to lab.mlpack environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -28,6 +28,7 @@ dependencies:
 - invoke=1.2
 - pandas-datareader
 - plotly
+- imbalanced-learn=0.8.0
 # C++ Kernel
 - xeus-cling
 - xtensor


### PR DESCRIPTION
Imbalanced-learn (imblearn) is required by SMOTE technique used in our resampling utility for c++ notebooks.