### PR TITLE
Trigger a new binder build.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - bqplot=0.12.20
 - dask=2020.12
 - matplotlib=3.1
-- pandas=1
+- pandas
 - python=3.7
 - scikit-image
 - scikit-learn


### PR DESCRIPTION
This is just to force a new binder build, so we get the latest sos-notebook package which fixes the await bug.