### PR TITLE
Fix binder "Error during build: .0.0 is not valid SemVer string" build issue.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - altair=4.1
 - bqplot=0.12.20
 - dask=2020.12
-- matplotlib=3.1
+- matplotlib
 - pandas
 - python=3.7
 - scikit-image
@@ -35,6 +35,7 @@ dependencies:
 - xwidgets
 - xframe
 # R Kernel
+- r-base=4.1.0
 - r-ggplot2
 - r-irkernel=1.0
 # mlpack


### PR DESCRIPTION
Fix binder "Error during build: .0.0 is not valid SemVer string" build issue.