### PR TITLE
Force version of libstdc++ to 9.3.0 to fix cling kernel

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -51,7 +51,7 @@ dependencies:
 - cython
 - numpy
 - pandas
-- gxx_linux-64
+- gxx_linux-64=9.3.0
 - mlpack
 - ensmallen
 # SoS

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,12 +1,7 @@
 set -ex
 
-# Install IJavascript kernel.
-npm install -g ijavascript
-ijsinstall
-
 # Install SoS kernels.
 pip install sos-xeus-cling sos-javascript sos-python sos-r sos-julia
-
 
 jupyter kernelspec remove -f xcpp11
 jupyter kernelspec remove -f xcpp17

--- a/binder/xeus-cling.hpp
+++ b/binder/xeus-cling.hpp
@@ -10,6 +10,6 @@
 #pragma cling load("/srv/conda/envs/notebook/lib/libboost_filesystem.so")
 #pragma cling load("/srv/conda/envs/notebook/lib/libomp.so")
 #pragma cling load("/srv/conda/envs/notebook/lib/libpython3.so")
-#pragma cling add_include_path("/srv/conda/envs/notebook/include/python3.9m/")
+#pragma cling add_include_path("/srv/conda/envs/notebook/include/python3.7m/")
 
 #define ARMA_DONT_USE_WRAPPER

--- a/scripts/jupyter-conda-setup.sh
+++ b/scripts/jupyter-conda-setup.sh
@@ -1,17 +1,17 @@
-#!/usr/bin/env/bash
+#!/usr/bin/env bash
 
 function cleanUp() {
     echo "**************"
     echo "Cleaning Up..."
     echo "**************"
     if [[ -f "./kernel.json" ]]; then
-    	rm kernel.json
+        rm kernel.json
     fi
     if [[ -f "./xeus-cling.hpp" ]]; then
-    	rm xeus-cling.hpp
+        rm xeus-cling.hpp
     fi
     if [[ -f "./environment.yml" ]]; then
-    	rm environment.yml
+        rm environment.yml
     fi
     if [[ -d "${CONDA_PREFIX}/share/jupyter/lab" ]]; then
         jupyter lab clean 


### PR DESCRIPTION
It seems like somehow libstdc++ got upgraded to 9.5.0 in the conda environment, but this is incompatible with the version of cling that gets installed.

This fix just forces the version to be 9.3.0, so it works again.

I also removed `ijavascript` because keeping it in there caused some build issue that I did not take the time to debug.

Also, I found that the system uses Python 3.7, not 3.9, so I updated the path in xeus-cling.hpp.

I tested this on mybinder.org and ran through the Avocado price prediction notebook successfully.