### PR TITLE
Apply the same preprocessing to the test set as to the training set

### DIFF
--- a/mnist_batch_norm/mnist_batch_norm.cpp
+++ b/mnist_batch_norm/mnist_batch_norm.cpp
@@ -172,8 +172,8 @@ int main()
   // https://www.kaggle.com/c/digit-recognizer/data
 
   data::Load("../data/mnist_test.csv", dataset, true);
-  mat testY = dataset.row(dataset.n_rows - 1);
-  dataset.shed_row(dataset.n_rows - 1); // Remove labels.
+  mat testY = dataset.row(0);
+  dataset.shed_row(0); // Remove labels.
 
   mat testPredOut;
   // Getting predictions on test data points .

--- a/mnist_simple/mnist_simple.cpp
+++ b/mnist_simple/mnist_simple.cpp
@@ -162,8 +162,9 @@ int main()
   // Loading test dataset (the one whose predicted labels
   // should be sent to kaggle website).
   data::Load("../data/mnist_test.csv", dataset, true);
-  arma::mat testY = dataset.row(dataset.n_rows - 1);
-  dataset.shed_row(dataset.n_rows - 1); // Strip labels before predicting.
+  arma::mat testY = dataset.row(0);
+  dataset.shed_row(0); // Strip labels before predicting.
+  dataset /= 255.0; // Apply the same normalization as to the training data.
 
   cout << "Predicting on test set..." << endl;
   arma::mat testPredOut;


### PR DESCRIPTION
I noticed while reading the CI logs for #209 that the test accuracy on `mnist_batch_norm` and `mnist_simple` was atrocious (9%!) even though the training and validation accuracies seemed fine.  A quick look indicated that this was because we were using the wrong dimension for labels, and for `mnist_simple` we weren't normalizing the test data.  Easy fix, and now the test accuracies for both are what is expected (95%+).