### PR TITLE
Adding Batch Norm layer to mnist example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ cmake-build-*
 *.so
 data
 plots
-mnist_*
+mnist_t*
 nn_*
 cifar_*
 covertype-rf

--- a/cpp/neural_networks/mnist_cnn/mnist_cnn.cpp
+++ b/cpp/neural_networks/mnist_cnn/mnist_cnn.cpp
@@ -120,6 +120,9 @@ int main()
                         2, // Stride along height.
                         true);
 
+  // Add BatchNorm.
+  model.Add<BatchNorm>();
+
   // Add the second convolution layer.
   model.Add<Convolution>(16, // Number of output activation maps.
                          5,  // Filter width.
@@ -136,6 +139,9 @@ int main()
   // Add the second pooling layer.
   model.Add<MaxPooling>(2, 2, 2, 2, true);
 
+  // Add BatchNorm
+  model.Add<BatchNorm>();
+  
   // Add the final dense layer.
   model.Add<Linear>(10);
   model.Add<LogSoftMax>();
@@ -200,7 +206,7 @@ int main()
   // Get predictions on test data points.
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
-  data::Load("../data/mnist_test.csv", dataset, true);
+  data::Load("../../../data/mnist_test.csv", dataset, true);
   const mat testX = dataset.submat(1, 0, dataset.n_rows - 1, dataset.n_cols - 1)
       / 256.0;
   const mat testY = dataset.row(0);


### PR DESCRIPTION
Some numbers I am sharing for comparison before and after.
After adding `BatchNorm`, the results are as follows.
```
Epoch 1/60
1.6259780 [====================================================================================================] 100% - ETA: 0s - loss: 1.62447
1080/1080 [====================================================================================================] 100% - 33.017s/epoch; 30ms/step; loss: 1.62597
Validation loss: 2578.69.
Epoch 2/60
0.3073710 [====================================================================================================] 100% - ETA: 0s - loss: 0.307087
1080/1080 [====================================================================================================] 100% - 33.4479s/epoch; 30ms/step; loss: 0.307371
Validation loss: 1474.22.
Epoch 3/60
0.1960040 [====================================================================================================] 100% - ETA: 0s - loss: 0.195822
1080/1080 [====================================================================================================] 100% - 66.869s/epoch; 61ms/step; loss: 0.196004
Validation loss: 1060.39.
Epoch 4/60
0.1427660 [====================================================================================================] 100% - ETA: 0s - loss: 0.142634
1080/1080 [====================================================================================================] 100% - 59.2336s/epoch; 54ms/step; loss: 0.142766
Validation loss: 806.362.

```
The final results are as follows.
```
Accuracy: train = 99.0722%,      valid = 98.0833%
Predicting on test set...
Accuracy: test = 98.2%
Saving predicted labels to "results.csv."...
Neural network model is saved to "model.bin"
Finished
```
Before using `BatchNorm`, the results are as follows.
```
Epoch 1/60
8.4917180 [====================================================================================================] 100% - ETA: 0s - loss: 8.48386
1080/1080 [====================================================================================================] 100% - 30.4392s/epoch; 28ms/step; loss: 8.49171
Validation loss: 10344.8.
Epoch 2/60
1.1411380 [====================================================================================================] 100% - ETA: 0s - loss: 1.14007
1080/1080 [====================================================================================================] 100% - 33.1457s/epoch; 30ms/step; loss: 1.14113
Validation loss: 4464.7.
Epoch 3/60
0.5980410 [====================================================================================================] 100% - ETA: 0s - loss: 0.597488
1080/1080 [====================================================================================================] 100% - 34.5802s/epoch; 32ms/step; loss: 0.598041
Validation loss: 2676.62.
Epoch 4/60
0.3828350 [====================================================================================================] 100% - ETA: 0s - loss: 0.38248
1080/1080 [====================================================================================================] 100% - 39.7242s/epoch; 36ms/step; loss: 0.382835
Validation loss: 1853.03.
```
As we can see, the model after `BatchNorm` started converging pretty early.
and final results are as follows.
```
Accuracy: train = 99.6444%,      valid = 98.1167%
Predicting on test set...
Accuracy: test = 98.33%
Saving predicted labels to "results.csv."...
Neural network model is saved to "model.bin"
Finished
```
Accuracy is pretty much the same just `0.1%` difference between before and after. Let me know if I am missing anything.