### PR TITLE
Add actions to replace mlpack-bot functionality.

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,22 @@
+# Once a PR has been approved by one member of the mlpack organization, a second
+# approving review will automatically be added 24 hours later.  This allows time
+# for other maintainers to take a look.
+name: Auto-approve pull requests
+on:
+  schedule:
+   # Run roughly every four hours.
+   - cron: "15 0,4,8,12,16,20 * * *"
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+     - name: Auto-approve pull requests
+       uses: rcurtin/actions/auto-approve@v1
+       with:
+         repo-token: ${{ secrets.GITHUB_TOKEN }}
+         approval-message:
+           'Second approval provided automatically after 24 hours. :+1:'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issues-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: "s: stale"
+          stale-pr-label: "s: stale"
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had any recent activity.  It will be closed in 7 days if no further activity occurs.  Thank you for your contributions! :+1:"
+          days-before-pr-stale: 30,
+          days-before-pr-close: 14
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "s: keep open"
+          exempt-pr-labels: "s: keep open"

--- a/.github/workflows/stickers.yml
+++ b/.github/workflows/stickers.yml
@@ -1,0 +1,17 @@
+# Post a message to new contributors that they can get some stickers mailed to
+# them.
+name: 'Stickers for new contributors'
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  sticker_comment:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+        # Forked version of first-interaction that runs only on first merged PR.
+      - uses: rcurtin/actions/stickers@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"


### PR DESCRIPTION
(Same as mlpack/ensmallen#405)

This adds three Github actions that replace the functionality of the poor departed mlpack-bot:

 * Auto-approval of a PR after 24 hours
 * Stale issues/PR closure
 * Post a message to new contributors that they can have stickers

These are the same as what the mlpack/mlpack repository uses.