### PR TITLE
Generate output filename from input filename

### DIFF
--- a/cpp/kmeans/dominant-colors/dominant-colors.cpp
+++ b/cpp/kmeans/dominant-colors/dominant-colors.cpp
@@ -255,6 +255,7 @@ void dominantColors(std::string PathToImage, std::string PathToColorBars)
 int main()
 {
   dominantColors("../../../data/jurassic-park.png", "jurassic-park-colors.png");
-  dominantColors("../../../data/the-grand-budapest-hotel.png", "the-grand-budapest-hotel-colors.png");
+  dominantColors("../../../data/the-grand-budapest-hotel.png",
+      "the-grand-budapest-hotel-colors.png");
   dominantColors("../../../data/the-godfather.png", "the-godfather-colors.png");
 }

--- a/cpp/kmeans/dominant-colors/dominant-colors.cpp
+++ b/cpp/kmeans/dominant-colors/dominant-colors.cpp
@@ -195,7 +195,7 @@ void GetColorBarData(std::string& values,
   colors = colorsString.str();
 }
 
-void dominantColors(std::string PathToImage)
+void dominantColors(std::string PathToImage, std::string PathToColorBars)
 {
   // Load the example image.
   arma::Mat<unsigned char> imageMatrix;
@@ -249,15 +249,12 @@ void dominantColors(std::string PathToImage)
   GetColorBarData(values, colors, cluster, assignments, centroids);
   
   // Show the dominant colors.
-  size_t pos = PathToImage.find_last_of("/\\") + 1;
-  size_t len = PathToImage.rfind(".png") - pos;
-  std::string pathToColorBars = PathToImage.substr(pos, len) + "-colors.png";
-  StackedBar(values, colors, pathToColorBars);
+  StackedBar(values, colors, PathToColorBars);
 }
 
 int main()
 {
-  dominantColors("../../../data/jurassic-park.png");
-  dominantColors("../../../data/the-grand-budapest-hotel.png");
-  dominantColors("../../../data/the-godfather.png");
+  dominantColors("../../../data/jurassic-park.png", "jurassic-park-colors.png");
+  dominantColors("../../../data/the-grand-budapest-hotel.png", "the-grand-budapest-hotel-colors.png");
+  dominantColors("../../../data/the-godfather.png", "the-godfather-colors.png");
 }

--- a/cpp/kmeans/dominant-colors/dominant-colors.cpp
+++ b/cpp/kmeans/dominant-colors/dominant-colors.cpp
@@ -249,7 +249,10 @@ void dominantColors(std::string PathToImage)
   GetColorBarData(values, colors, cluster, assignments, centroids);
   
   // Show the dominant colors.
-  StackedBar(values, colors, "jurassic-park-colors.png");
+  size_t pos = PathToImage.find_last_of("/\\") + 1;
+  size_t len = PathToImage.rfind(".png") - pos;
+  std::string pathToColorBars = PathToImage.substr(pos, len) + "-colors.png";
+  StackedBar(values, colors, pathToColorBars);
 }
 
 int main()


### PR DESCRIPTION
Fixes bug where it wrote the color bars to `jurassic-park-colors.png` no matter which image you gave it.