### PR TITLE
Minor bugfixes for LSTM example.

### DIFF
--- a/cpp/lstm/dga_detection/lstm_dga_detection_predict.cpp
+++ b/cpp/lstm/dga_detection/lstm_dga_detection_predict.cpp
@@ -15,6 +15,10 @@
  * To keep the model small and the code fast, we use `float` as a datatype
  * instead of the default `double`.
  */
+
+// This must be defined to avoid RNN::serialize() throwing an error---we know
+// what we are doing and have manually registered the layer types we care about.
+#define MLPACK_ANN_IGNORE_SERIALIZATION_WARNING
 #include <mlpack.hpp>
 
 // To keep compilation time and program size down, we only register
@@ -142,10 +146,11 @@ int main(int argc, char** argv)
     const float benignLikelihood = ComputeLikelihood(benignOutput, response);
     const float maliciousLikelihood = ComputeLikelihood(maliciousOutput,
         response);
+    const float score = benignLikelihood - maliciousLikelihood;
 
     if (benignLikelihood > maliciousLikelihood)
-      cout << "benign" << endl;
+      cout << "benign (score " << score << ")" << std::endl;
     else
-      cout << "malicious" << endl;
+      cout << "malicious (score " << -score << ")" << std::endl;
   }
 }

--- a/cpp/lstm/dga_detection/lstm_dga_detection_train.cpp
+++ b/cpp/lstm/dga_detection/lstm_dga_detection_train.cpp
@@ -26,6 +26,10 @@
  * Train the model on the `dga_domains.csv` file in the data/ directory in the
  * repository (once you have run `scripts/download_data_set.py`).
  */
+
+// This must be defined to avoid RNN::serialize() throwing an error---we know
+// what we are doing and have manually registered the layer types we care about.
+#define MLPACK_ANN_IGNORE_SERIALIZATION_WARNING
 #include <mlpack.hpp>
 
 // To keep compilation time and program size down, we only register
@@ -115,7 +119,7 @@ void PrepareData(const vector<string>& domains,
 size_t ComputeCorrect(const arma::fcube& benignPredictions,
                       const arma::fcube& maliciousPredictions,
                       const arma::fcube& labels,
-                      const arma::uvec& sequenceLengths,
+                      const arma::urowvec& sequenceLengths,
                       const bool malicious)
 {
   size_t correct = 0;


### PR DESCRIPTION
I noticed these small problems while trying to run the DGA detector example.  Since we are manually registering layers for serialization (to keep the code generation time and size down), we have to specify the define that indicates to FFN/RNN that serialization is still allowed.